### PR TITLE
refactor: extract a NamingScheme from Container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
             - name: Install
               uses: ./.github/actions/install
               with:
@@ -34,7 +34,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
             - name: Install
               uses: ./.github/actions/install
               with:
@@ -48,7 +48,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             - name: Install
               uses: ./.github/actions/install
@@ -68,7 +68,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             - name: Install
               uses: ./.github/actions/install
@@ -85,7 +85,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             - name: Install
               uses: ./.github/actions/install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
             - name: Checkout
               if: steps.release.outputs.releases_created == 'true'
-              uses: actions/checkout@v6
+              uses: actions/checkout@v7
 
             - name: Install
               if: steps.release.outputs.releases_created == 'true'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './module';
+export * from './naming';
 export * from './types';

--- a/src/module.ts
+++ b/src/module.ts
@@ -13,6 +13,7 @@ import {
 import path from 'node:path';
 import { createMerger, isObject } from 'smob';
 import { expandPath, getPathInfo } from 'pathtrace';
+import { NamingScheme } from './naming';
 import type {
     Element,
     MergeFn,
@@ -27,10 +28,17 @@ export class Container {
 
     protected readonly options : NormalizedOptions;
 
+    protected readonly naming : NamingScheme;
+
     constructor(options: Options = {}) {
         this.options = this.normalizeOptions(options);
         this.items = [];
         this.itemsSorted = true;
+        this.naming = new NamingScheme({
+            prefix: this.options.prefix,
+            suffix: this.options.suffix,
+            extensions: this.options.extensions,
+        });
     }
 
     get<T = any>(key: string | string[]) : T | undefined {
@@ -145,36 +153,7 @@ export class Container {
             return;
         }
 
-        let inputNormalized = input.replace(/\\/g, '/');
-        if (inputNormalized.includes('/')) {
-            inputNormalized = inputNormalized.substring(inputNormalized.lastIndexOf('/') + 1);
-        }
-
-        let name = inputNormalized.substring(0, inputNormalized.lastIndexOf('.'));
-
-        if (
-            this.options.prefix &&
-            name.startsWith(this.options.prefix)
-        ) {
-            let startIndex = this.options.prefix.length;
-            if (name.charAt(startIndex) === '.') {
-                startIndex++;
-            }
-
-            name = name.substring(startIndex);
-        }
-
-        if (
-            this.options.suffix &&
-            name.endsWith(this.options.suffix)
-        ) {
-            let startIndex = name.length - this.options.suffix.length;
-            if (name.charAt(startIndex - 1) === '.') {
-                startIndex--;
-            }
-
-            name = name.substring(0, startIndex);
-        }
+        const name = this.naming.toName(input);
 
         this.items.push({
             data,
@@ -185,29 +164,7 @@ export class Container {
     }
 
     protected async findFiles(cwd?: string[] | string) : Promise<string[]> {
-        const patterns : string[] = [];
-        const extension = `{${this.options.extensions.join(',')}}`;
-
-        if (
-            this.options.prefix &&
-            this.options.suffix
-        ) {
-            patterns.push(`${this.options.prefix}.*.${this.options.suffix}.${extension}`);
-        } else if (this.options.prefix) {
-            patterns.push(
-                `${this.options.prefix}.${extension}`,
-                `${this.options.prefix}.*.${extension}`,
-            );
-        } else if (this.options.suffix) {
-            patterns.push(
-                `${this.options.suffix}.${extension}`,
-                `*.${this.options.suffix}.${extension}`,
-            );
-        } else {
-            patterns.push(`*.${extension}`);
-        }
-
-        const locations = await locateMany(patterns, { cwd, onlyFiles: true });
+        const locations = await locateMany(this.naming.toPatterns(), { cwd, onlyFiles: true });
 
         return locations.map(
             (location) => buildFilePath(location),

--- a/src/naming.ts
+++ b/src/naming.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type NamingSchemeOptions = {
+    prefix?: string,
+    suffix?: string,
+    extensions: string[]
+};
+
+/**
+ * Owns both directions of the prefix/suffix/extension file-naming convention:
+ * building the glob patterns that discover matching files, and deriving an
+ * element name from a discovered file path.
+ */
+export class NamingScheme {
+    protected readonly prefix?: string;
+
+    protected readonly suffix?: string;
+
+    protected readonly extensions: string[];
+
+    constructor(options: NamingSchemeOptions) {
+        this.prefix = options.prefix;
+        this.suffix = options.suffix;
+        this.extensions = options.extensions;
+    }
+
+    /**
+     * Glob patterns that match files following this convention (non-recursive).
+     */
+    toPatterns() : string[] {
+        const patterns : string[] = [];
+        const extension = `{${this.extensions.join(',')}}`;
+
+        if (
+            this.prefix &&
+            this.suffix
+        ) {
+            patterns.push(`${this.prefix}.*.${this.suffix}.${extension}`);
+        } else if (this.prefix) {
+            patterns.push(
+                `${this.prefix}.${extension}`,
+                `${this.prefix}.*.${extension}`,
+            );
+        } else if (this.suffix) {
+            patterns.push(
+                `${this.suffix}.${extension}`,
+                `*.${this.suffix}.${extension}`,
+            );
+        } else {
+            patterns.push(`*.${extension}`);
+        }
+
+        return patterns;
+    }
+
+    /**
+     * Derive the element name from a file path (base name, prefix/suffix stripped).
+     */
+    toName(filePath: string) : string {
+        let inputNormalized = filePath.replace(/\\/g, '/');
+        if (inputNormalized.includes('/')) {
+            inputNormalized = inputNormalized.substring(inputNormalized.lastIndexOf('/') + 1);
+        }
+
+        let name = inputNormalized.substring(0, inputNormalized.lastIndexOf('.'));
+
+        if (
+            this.prefix &&
+            name.startsWith(this.prefix)
+        ) {
+            let startIndex = this.prefix.length;
+            if (name.charAt(startIndex) === '.') {
+                startIndex++;
+            }
+
+            name = name.substring(startIndex);
+        }
+
+        if (
+            this.suffix &&
+            name.endsWith(this.suffix)
+        ) {
+            let startIndex = name.length - this.suffix.length;
+            if (name.charAt(startIndex - 1) === '.') {
+                startIndex--;
+            }
+
+            name = name.substring(0, startIndex);
+        }
+
+        return name;
+    }
+}

--- a/test/unit/naming.spec.ts
+++ b/test/unit/naming.spec.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2024.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { NamingScheme } from '../../src';
+
+/**
+ * Convert one of the glob patterns emitted by {@link NamingScheme.toPatterns}
+ * into an anchored RegExp, so tests can assert a pattern actually matches a
+ * synthetic file name. Only the glob features the scheme uses are supported:
+ * `*` (any run of non-separator chars), `{a,b,c}` brace alternation, and
+ * literal dots.
+ */
+function globToRegExp(pattern: string): RegExp {
+    let source = '';
+    for (const char of pattern) {
+        if (char === '*') {
+            source += '[^/]*';
+        } else if (char === '{') {
+            source += '(';
+        } else if (char === '}') {
+            source += ')';
+        } else if (char === ',') {
+            source += '|';
+        } else {
+            source += char.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+    }
+
+    return new RegExp(`^${source}$`);
+}
+
+function matchesAnyPattern(scheme: NamingScheme, fileName: string): boolean {
+    return scheme.toPatterns().some((pattern) => globToRegExp(pattern).test(fileName));
+}
+
+describe('src/naming', () => {
+    describe('toPatterns', () => {
+        it('should build a middle-segment pattern for prefix and suffix', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toPatterns()).toEqual([
+                'project.*.server.{conf}',
+            ]);
+        });
+
+        it('should build patterns for a prefix only', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toPatterns()).toEqual([
+                'project.{conf}',
+                'project.*.{conf}',
+            ]);
+        });
+
+        it('should build patterns for a suffix only', () => {
+            const scheme = new NamingScheme({
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toPatterns()).toEqual([
+                'server.{conf}',
+                '*.server.{conf}',
+            ]);
+        });
+
+        it('should build a wildcard pattern for neither prefix nor suffix', () => {
+            const scheme = new NamingScheme({ extensions: ['conf'] });
+
+            expect(scheme.toPatterns()).toEqual([
+                '*.{conf}',
+            ]);
+        });
+
+        it('should brace-expand multiple extensions', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['yml', 'yaml'],
+            });
+
+            expect(scheme.toPatterns()).toEqual([
+                'project.{yml,yaml}',
+                'project.*.{yml,yaml}',
+            ]);
+        });
+    });
+
+    describe('toName', () => {
+        it('should strip a prefix', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('project.server.conf')).toEqual('server');
+        });
+
+        it('should strip a suffix', () => {
+            const scheme = new NamingScheme({
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('project.server.conf')).toEqual('project');
+        });
+
+        it('should strip both a prefix and a suffix', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('project.core.server.conf')).toEqual('core');
+        });
+
+        it('should strip neither a prefix nor a suffix', () => {
+            const scheme = new NamingScheme({ extensions: ['conf'] });
+
+            expect(scheme.toName('project.conf')).toEqual('project');
+        });
+
+        it('should keep dotted middle segments intact', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('project.server.core.conf')).toEqual('server.core');
+        });
+
+        it('should reduce a base file to an empty name when it is only the prefix', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('project.conf')).toEqual('');
+        });
+
+        it('should only strip a prefix at a dot boundary', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('projectfoo.conf')).toEqual('foo');
+        });
+
+        it('should only strip a suffix at a dot boundary', () => {
+            const scheme = new NamingScheme({
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('fooserver.conf')).toEqual('foo');
+        });
+
+        it('should leave the name untouched when the prefix does not match', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('other.conf')).toEqual('other');
+        });
+
+        it('should extract the base name from a nested posix path', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('/abs/path/test/data/project.server.conf')).toEqual('server');
+        });
+
+        it('should extract the base name from a windows-style path', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            expect(scheme.toName('C:\\configs\\project.server.conf')).toEqual('server');
+        });
+    });
+
+    describe('round-trip', () => {
+        it('should match a prefix+suffix file name against its own patterns', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            const fileName = 'project.core.server.conf';
+
+            expect(matchesAnyPattern(scheme, fileName)).toBe(true);
+            expect(scheme.toName(fileName)).toEqual('core');
+        });
+
+        it('should match a prefix-only file name against its own patterns', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['conf'],
+            });
+
+            const fileName = 'project.server.conf';
+
+            expect(matchesAnyPattern(scheme, fileName)).toBe(true);
+            expect(scheme.toName(fileName)).toEqual('server');
+        });
+
+        it('should match a suffix-only file name against its own patterns', () => {
+            const scheme = new NamingScheme({
+                suffix: 'server',
+                extensions: ['conf'],
+            });
+
+            const fileName = 'project.server.conf';
+
+            expect(matchesAnyPattern(scheme, fileName)).toBe(true);
+            expect(scheme.toName(fileName)).toEqual('project');
+        });
+
+        it('should match an unprefixed file name against its own pattern', () => {
+            const scheme = new NamingScheme({ extensions: ['conf'] });
+
+            const fileName = 'project.conf';
+
+            expect(matchesAnyPattern(scheme, fileName)).toBe(true);
+            expect(scheme.toName(fileName)).toEqual('project');
+        });
+
+        it('should match across every extension in a multi-extension scheme', () => {
+            const scheme = new NamingScheme({
+                prefix: 'project',
+                extensions: ['yml', 'yaml'],
+            });
+
+            for (const extension of ['yml', 'yaml']) {
+                expect(matchesAnyPattern(scheme, `project.web.${extension}`)).toBe(true);
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Extracts the file-naming convention (`prefix` / `suffix` / `extensions`) out of `Container` into a new, pure `NamingScheme` class (`src/naming.ts`) that owns **both** directions of the convention:

- `toPatterns(): string[]` — builds the non-recursive glob patterns used for discovery (the four prefix/suffix branches + brace-expanded extensions), previously inline in `Container.findFiles`.
- `toName(filePath: string): string` — derives an element name from a file path (base-name extraction, separator normalization, prefix/suffix stripping with dot-boundary handling), previously inline in `Container.loadFile`.

The convention used to live in two places ~40 lines apart that had to agree but shared no abstraction — the exact seam where the recent `locter` migration bug lived (`**` → `*`). Uniting the forward (*convention → patterns*) and reverse (*path → name*) halves in one object means they can no longer drift apart. This follows plan `002-naming-scheme` (Candidate 2).

## Preserved API

- Public `Container` surface (`constructor`, `load`, `loadFile`, `get`) is **unchanged**.
- Behavior-preserving: the moved logic is byte-for-byte identical, so the emitted glob patterns and derived names are the same as before. `Container` builds the scheme from its normalized options and delegates:
  - `findFiles` → `locateMany(this.naming.toPatterns(), { cwd, onlyFiles: true })`
  - `loadFile` → `const name = this.naming.toName(input)`
- `NamingScheme` (and `NamingSchemeOptions`) is additive public API, re-exported from the `src/index.ts` barrel.

## Tests

New `test/unit/naming.spec.ts` adds direct boundary coverage that the old indirect, full-directory-load tests never gave:

- **`toPatterns()`** for all four prefix/suffix combinations plus a multi-extension set.
- **`toName()`** for prefix-only / suffix-only / both / neither, dotted middle segments, dot-boundary stripping, nested POSIX paths, and Windows-style separators.
- **Round-trip property**: a synthetic file name the scheme would produce is matched by at least one pattern the scheme emits (and strips back to the expected element name) — guarding the forward/reverse pair against future drift.

The existing option-driven `Container` tests are kept as thin integration checks.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run test:coverage` — 31 tests pass; coverage 98.13% statements / 93.33% branches / 100% functions / 98.09% lines (all above the enforced 80% floor; `naming.ts` is 100% / 100%)
- `npm run build` — succeeds
