### PR TITLE
fix(deps): require pathtrace 2.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "MIT",
             "dependencies": {
                 "locter": "^4.1.0",
-                "pathtrace": "^2.2.1",
+                "pathtrace": "^2.2.2",
                 "smob": "^1.6.2"
             },
             "devDependencies": {
@@ -4150,9 +4150,9 @@
             "license": "MIT"
         },
         "node_modules/pathtrace": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.1.tgz",
-            "integrity": "sha512-NgmSwfSTcQZF+r90cUa/mkacIEObkd7FLjQNHsLXXOxmtTYDFWz9mV9aElPVx3wwj2dS5/y2exqJUz+7aUxnKg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.2.tgz",
+            "integrity": "sha512-2uXz62JShMMoFuDgTsUiW4sJnDfDdGLQLcw7scE4pOWfH7cBrKf1LRKho8xHwbkomY/rFbCNJT47UNUNvwvTBQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "homepage": "https://github.com/tada5hi/confinity#readme",
     "dependencies": {
         "locter": "^4.1.0",
-        "pathtrace": "^2.2.1",
+        "pathtrace": "^2.2.2",
         "smob": "^1.6.2"
     },
     "devDependencies": {

--- a/test/unit/fsstore.spec.ts
+++ b/test/unit/fsstore.spec.ts
@@ -100,6 +100,10 @@ describe('src/store FSStore', () => {
         it('should carry a class instance through untouched', async () => {
             class Custom {
                 readonly value = 1;
+
+                get derived() {
+                    return this.value + 1;
+                }
             }
             const instance = new Custom();
             const read : Reader = async () => ({ custom: instance });
@@ -107,6 +111,11 @@ describe('src/store FSStore', () => {
             await store.loadFile('app.conf');
 
             expect(store.getSync<Record<string, unknown>>('app')?.custom).toBe(instance);
+
+            // A `.ts`/`.mjs` config may export a class instance, and an accessor
+            // on its prototype is data as far as a caller is concerned.
+            expect(store.getSync('app.custom.value')).toEqual(1);
+            expect(store.getSync('app.custom.derived')).toEqual(2);
         });
 
         it('should honor absolute paths and load arrays in parallel', async () => {

--- a/test/unit/store.spec.ts
+++ b/test/unit/store.spec.ts
@@ -279,6 +279,22 @@ describe('src/store', () => {
             expect(store.has(`db.${key}`)).toBe(false);
         });
 
+        it('should resolve an accessor declared on a prototype', () => {
+            // Config exported from a `.ts`/`.mjs` module may carry class
+            // instances; an accessor on the prototype must read like a field.
+            const prototype = {};
+            Object.defineProperty(prototype, 'derived', {
+                get: () => 'computed',
+                configurable: true,
+            });
+
+            const store = new Store();
+            store.add({ name: '', data: { db: Object.create(prototype) } });
+
+            expect(store.getSync('db.derived')).toEqual('computed');
+            expect(store.has('db.derived')).toBe(true);
+        });
+
         it('should still resolve ordinary keys and array entries', () => {
             const store = new Store();
             store.add({ name: '', data: { db: { password: 'hunter2' }, hosts: ['a', 'b'] } });


### PR DESCRIPTION
`pathtrace@2.2.1` stopped resolving accessors declared on a class prototype ([tada5hi/pathtrace#188](https://github.com/tada5hi/pathtrace/pull/188), fixed in 2.2.2). confinity 2.0.0 requires `^2.2.1`, so a lockfile generated while 2.2.1 was latest pins the broken patch.

## It is reachable through confinity

`toElement`'s `sanitize` deliberately carries exotic values through **by reference** — functions, `Date`s and class instances that a `.ts`/`.mjs` config may legitimately export. So an accessor on such an instance is resolved by pathtrace, and on 2.2.1 it reads as absent:

```ts
// project.config.ts
class Database {
    readonly host = 'localhost';
    get url() { return `postgres://${this.host}`; }
}
export default { db: new Database() };
```

```ts
store.getSync('db.url');   // 2.2.1 → undefined     2.2.2 → 'postgres://localhost'
store.has('db.url');       // 2.2.1 → false         2.2.2 → true
```

## Why the suite did not catch it

Every fixture is plain data, so nothing ever resolved a path through a prototype. That is the actual gap, and the version bump alone would leave it open — the same class of bug could return unnoticed.

Two tests now cover it: one at the store boundary (`store.spec.ts`, under *key resolution safety*) and one through the reader port on a real class instance (`fsstore.spec.ts`). Both fail against 2.2.1:

```
× should resolve an accessor declared on a prototype
Tests  1 failed | 122 skipped (123)
```

and pass against 2.2.2. The floor is a correctness requirement, not housekeeping.

## Verification

123 tests (up from 122), 98.89% statements / 96.2% branches / 100% functions. Build, typecheck and lint clean.

Downstream: authup's [#3353](https://github.com/authup/authup/pull/3353) is fully green with `confinity@2.0.0` + `pathtrace@2.2.2`, including the token-workflow suites that 2.2.1 broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of class instances and prototype accessors when reading stored data.
  * Property paths now correctly resolve computed values exposed through getters.

* **Tests**
  * Added coverage for accessor-based property resolution and class instance data retrieval.

* **Chores**
  * Updated the `pathtrace` dependency to version 2.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->