### PR TITLE
chore: fill in package keywords and tighten the description

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "confinity",
     "version": "2.0.0",
     "type": "module",
-    "description": "This is a library to load configurations in the context of a multi package application",
+    "description": "Load & merge configuration across a multi-package application.",
     "author": {
         "name": "Peter Placzek",
         "email": "contact@tada5hi.net",
@@ -37,7 +37,22 @@
         "lint:fix": "npm run lint -- --fix",
         "prepare": "husky"
     },
-    "keywords": [],
+    "keywords": [
+        "config",
+        "configuration",
+        "config-loader",
+        "config-file",
+        "settings",
+        "deep-merge",
+        "dotted-path",
+        "multi-package",
+        "monorepo",
+        "esm",
+        "typescript",
+        "conf",
+        "json",
+        "yaml"
+    ],
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
Follow-up to updating the repository description and topics — the npm-facing metadata had the same gaps.

## `keywords` was empty

`"keywords": []`, so the package is effectively unsearchable on npm. Every other single-package library in the org populates it — locter (13), pathtrace (8), smob (6) — so this is the outlier rather than a deliberate choice. The set mirrors the repository topics:

```
config, configuration, config-loader, config-file, settings,
deep-merge, dotted-path, multi-package, monorepo,
esm, typescript, conf, json, yaml
```

`conf`/`json`/`yaml` follow locter's precedent of listing supported formats; `deep-merge` follows smob's.

## Description

Was: *"This is a library to load configurations in the context of a multi package application"*

Now: *"Load & merge configuration across a multi-package application."*

Two reasons beyond taste — it was the only description in the org opening with "This is a library to …", and "multi package" was unhyphenated. It now matches the README tagline.

## Repository metadata (already applied, no code change)

- **Description** → "Load & merge configuration across a multi-package application: discover .conf, JSON, YAML and TS/JS config files, and read them through a dotted-path getter." The previous one said what it was *for* but not what it *does*, unlike its siblings.
- **Topics** → added `deep-merge`, `config-file`, `json`, `yaml` to the existing nine.
- **Homepage** → deliberately left empty, matching pathtrace/locter/smob; only the repos with docs sites (rapiq, validup) set it.

## Note on release

This is a `chore:`, so release-please will not cut a version for it on its own — the new metadata reaches npm with the next release. [#101](https://github.com/tada5hi/confinity/pull/101) is a `fix(deps):` that will cut 2.0.1, so merging this first means both ship together.
